### PR TITLE
Massive update/simplification to package 1.6.0~rc4

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+docker.io (1.6.0~rc4~dfsg1-1) UNRELEASED; urgency=low
+
+  [ Tianon Gravi ]
+  * Update to 1.6.0-rc4 upstream release
+    - drop golang 1.2 support (no longer supported upstream)
+    - update Homepage to https://dockerproject.com
+    - add check-config.sh to /usr/share/docker.io/contrib
+    - add "distribution" as a new multitarball orig
+    - backport auto "btrfs_noversion" patch from
+      https://github.com/docker/docker/pull/12048
+      (simplifying our logic for detecting whether to use it)
+    - switch from dh-golang to direct install since we're not actually using the
+      features it offers (due to upstream's build system)
+    - enable "docker.service" on boot by default for restart policies to work
+
+ -- Tianon Gravi <admwiggin@gmail.com>  Tue, 24 Mar 2015 09:01:14 -0600
+
 docker.io (1.5.0~dfsg1-1) experimental; urgency=low
 
   * Update to 1.5.0 upstream release (Closes: #773495)

--- a/debian/control
+++ b/debian/control
@@ -8,27 +8,24 @@ Uploaders: Docker Packaging Team <docker-maint@lists.alioth.debian.org>,
 Build-Depends: bash-completion,
                btrfs-tools,
                debhelper (>=9),
-               dh-golang (>= 1.1),
                dh-systemd,
                go-md2man,
-               golang (>= 2:1.2-3~),
-               golang (>= 2:1.2.1-2~) | golang (<< 2:1.2.1~),
                golang (>= 2:1.3-4~) | golang (= 2:1.3-1) | golang (<< 2:1.3~),
                golang-context-dev (>= 0.0~git20140604~),
-               golang-dbus-dev (>= 1~),
+               golang-dbus-dev (>= 2~),
                golang-fsnotify-dev (>= 1.0.4~),
                golang-go-patricia-dev (>= 1.0.1~),
                golang-go-systemd-dev (>= 2~),
                golang-go.net-dev (>= 0.0~hg20130530~),
-               golang-gocapability-dev (>= 0.0~git20140516~),
+               golang-gocapability-dev (>= 0.0~git20150218~),
                golang-gosqlite-dev (>= 0.0~hg20130530~),
-               golang-logrus-dev (>= 0.6.0~),
+               golang-logrus-dev (>= 0.7.1~),
                golang-mux-dev (>= 0.0~git20140505~),
                golang-pty-dev (>= 0.0~git20141217~),
                libapparmor-dev,
                libdevmapper-dev
 Standards-Version: 3.9.6
-Homepage: https://github.com/docker/docker
+Homepage: https://dockerproject.com
 Vcs-Git: git://anonscm.debian.org/docker/docker.io.git
 Vcs-Browser: http://anonscm.debian.org/cgit/docker/docker.io.git
 

--- a/debian/docker.io.install
+++ b/debian/docker.io.install
@@ -1,4 +1,5 @@
 contrib/*-integration usr/share/docker.io/contrib/
+contrib/check-config.sh usr/share/docker.io/contrib/
 contrib/completion/zsh/_docker usr/share/zsh/vendor-completions/
 contrib/init/systemd/docker.service lib/systemd/system/
 contrib/init/systemd/docker.socket lib/systemd/system/

--- a/debian/helpers/download-libcontainer
+++ b/debian/helpers/download-libcontainer
@@ -7,7 +7,7 @@ pkg="$(dpkg-parsechangelog -SSource)"
 ver="$(dpkg-parsechangelog -SVersion)"
 origVer="${ver%-*}" # strip everything from the last dash
 origVer="$(echo "$origVer" | sed -r 's/^[0-9]+://')" # strip epoch
-upstreamVer="${origVer%%[+~]*}"
+upstreamVer="${origVer%%[+~]dfsg*}"
 origTarballPrefix="${DOCKER_TARBALLS}/${pkg}_${origVer}.orig"
 unprunedTarballPrefix="${DOCKER_TARBALLS}/${pkg}_${upstreamVer}.orig"
 
@@ -52,4 +52,13 @@ if libtrustCommit="$(get_hack_vendor | grep -m1 '^clone git github.com/docker/li
 	echo "  (from libtrust commit $libtrustCommit)"
 
 	"$(dirname "$(readlink -f "$BASH_SOURCE")")/../repack.sh" --upstream-version "$upstreamVer" "${unprunedTarballPrefix}-libtrust.tar.gz"
+fi
+
+if distributionCommit="$(get_hack_vendor | grep -m1 '^clone git github.com/docker/distribution ' | cut -d' ' -f4)" && [ "$distributionCommit" ]; then
+	$curl "https://github.com/docker/distribution/archive/${distributionCommit}.tar.gz" > "${unprunedTarballPrefix}-distribution.tar.gz"
+
+	echo "successfully fetched ${unprunedTarballPrefix}-distribution.tar.gz"
+	echo "  (from distribution commit $distributionCommit)"
+
+	"$(dirname "$(readlink -f "$BASH_SOURCE")")/../repack.sh" --upstream-version "$upstreamVer" "${unprunedTarballPrefix}-distribution.tar.gz"
 fi

--- a/debian/helpers/gitcommit.sh
+++ b/debian/helpers/gitcommit.sh
@@ -13,7 +13,7 @@ fi
 
 if [ "${uVersion%-dev}" = "$uVersion" ]; then
 	# this is a straight-up release!  easy-peasy
-	exec awk '/^'"$uVersion"':/ { print $2 }' debian/upstream-version-gitcommits
+	exec awk -F ': ' '$1 == "'"$uVersion"'" { print $2 }' debian/upstream-version-gitcommits
 fi
 
 # must be a nightly, so let's look for clues about what the git commit is

--- a/debian/patches/12048-auto-btrfs_noversion.patch
+++ b/debian/patches/12048-auto-btrfs_noversion.patch
@@ -1,0 +1,72 @@
+From 3761955e8c1e7534026c469186c3f66c18e77cbc Mon Sep 17 00:00:00 2001
+From: Tianon Gravi <admwiggin@gmail.com>
+Date: Fri, 3 Apr 2015 01:30:12 -0600
+Subject: [PATCH] Change the btrfs_noversion check to be automatic
+Applied-Upstream: https://github.com/docker/docker/pull/12048
+
+Signed-off-by: Andrew "Tianon" Page <admwiggin@gmail.com>
+---
+ Dockerfile           | 2 +-
+ hack/make.sh         | 8 ++++++++
+ project/PACKAGERS.md | 9 +--------
+ 3 files changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/Dockerfile b/Dockerfile
+index 6c6e0b5..b54fda5 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -138,7 +138,7 @@ RUN useradd --create-home --gid docker unprivilegeduser
+ 
+ VOLUME /var/lib/docker
+ WORKDIR /go/src/github.com/docker/docker
+-ENV DOCKER_BUILDTAGS apparmor selinux btrfs_noversion
++ENV DOCKER_BUILDTAGS apparmor selinux
+ 
+ # Let us use a .bashrc file
+ RUN ln -sfv $PWD/.bashrc ~/.bashrc
+diff --git a/hack/make.sh b/hack/make.sh
+index 118d432..4117469 100755
+--- a/hack/make.sh
++++ b/hack/make.sh
+@@ -98,6 +98,14 @@ if [ "$DOCKER_EXECDRIVER" = 'lxc' ]; then
+ 	DOCKER_BUILDTAGS+=' test_no_exec'
+ fi
+ 
++# test whether "btrfs/version.h" exists and apply btrfs_noversion appropriately
++if \
++	command -v gcc &> /dev/null \
++	&& ! gcc -E - &> /dev/null <<<'#include <btrfs/version.h>' \
++; then
++	DOCKER_BUILDTAGS+=' btrfs_noversion'
++fi
++
+ # Use these flags when compiling the tests and final binary
+ 
+ IAMSTATIC='true'
+diff --git a/project/PACKAGERS.md b/project/PACKAGERS.md
+index 701e552..5704b0a 100644
+--- a/project/PACKAGERS.md
++++ b/project/PACKAGERS.md
+@@ -58,8 +58,7 @@ To build the Docker daemon, you will additionally need:
+ * libdevmapper version 1.02.68-cvs (2012-01-26) or later from lvm2 version
+   2.02.89 or later
+ * btrfs-progs version 3.16.1 or later (unless using an older version is
+-  absolutely necessary, in which case 3.8 is the minimum and the note below
+-  regarding `btrfs_noversion` applies)
++  absolutely necessary, in which case 3.8 is the minimum)
+ 
+ Be sure to also check out Docker's Dockerfile for the most up-to-date list of
+ these build-time dependencies.
+@@ -163,12 +162,6 @@ SELinux, you will need to use the `selinux` build tag:
+ export DOCKER_BUILDTAGS='selinux'
+ ```
+ 
+-If your version of btrfs-progs (also called btrfs-tools) is < 3.16.1, then you
+-will need the following tag to not check for btrfs version headers:
+-```bash
+-export DOCKER_BUILDTAGS='btrfs_noversion'
+-```
+-
+ There are build tags for disabling graphdrivers as well. By default, support
+ for all graphdrivers are built in.
+ 

--- a/debian/patches/fatal-error-old-kernels.patch
+++ b/debian/patches/fatal-error-old-kernels.patch
@@ -4,14 +4,14 @@ Author: Tianon Gravi <admwiggin@gmail.com>
 Reviewed-by: Paul Tagliamonte <paultag@debian.org>
 
 diff --git a/daemon/daemon.go b/daemon/daemon.go
-index 632b9ab..5df7a54 100644
+index 6a27a08..eb366a1 100644
 --- a/daemon/daemon.go
 +++ b/daemon/daemon.go
-@@ -1129,7 +1129,7 @@ func checkKernelAndArch() error {
+@@ -1257,7 +1257,7 @@ func checkKernel() error {
  	} else {
  		if kernel.CompareKernelVersion(k, &kernel.KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}) < 0 {
  			if os.Getenv("DOCKER_NOWARN_KERNEL_VERSION") == "" {
--				log.Infof("WARNING: You are running linux kernel version %s, which might be unstable running docker. Please upgrade your kernel to 3.8.0.", k.String())
+-				log.Warnf("You are running linux kernel version %s, which might be unstable running docker. Please upgrade your kernel to 3.8.0.", k.String())
 +				log.Fatalf("ERROR: You are running Linux kernel version %s, which is unsupported for running Docker. Please upgrade your kernel to 3.8+.", k.String())
  			}
  		}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,6 @@
+# https://github.com/docker/docker/pull/12048!
+12048-auto-btrfs_noversion.patch
+
 # Once upstream kills the archive/tar vendoring, remove this patch
 upstream-patched-archive-tar.patch
 

--- a/debian/patches/upstream-patched-archive-tar.patch
+++ b/debian/patches/upstream-patched-archive-tar.patch
@@ -3,7 +3,7 @@ Description: "archive/tar" patch for upstreamed xattrs patch
 Applied-Upstream: when golang-1.4 is broadly packaged (scheduled to be released 2014-12-01)
 
 diff --git a/graph/tags_unit_test.go b/graph/tags_unit_test.go
-index 58ad8ed..0b06f3e 100644
+index c1a686b..90ea049 100644
 --- a/graph/tags_unit_test.go
 +++ b/graph/tags_unit_test.go
 @@ -7,11 +7,11 @@ import (
@@ -20,21 +20,21 @@ index 58ad8ed..0b06f3e 100644
  
  const (
 diff --git a/integration-cli/docker_api_containers_test.go b/integration-cli/docker_api_containers_test.go
-index 5dce388..fca39c4 100644
+index ea2f245..4f7b482 100644
 --- a/integration-cli/docker_api_containers_test.go
 +++ b/integration-cli/docker_api_containers_test.go
-@@ -11,8 +11,8 @@ import (
+@@ -9,8 +9,8 @@ import (
  	"testing"
  	"time"
  
 +	"archive/tar"
- 	"github.com/docker/docker/api/stats"
+ 	"github.com/docker/docker/api/types"
 -	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
  )
  
  func TestContainerApiGetAll(t *testing.T) {
 diff --git a/integration-cli/docker_cli_push_test.go b/integration-cli/docker_cli_push_test.go
-index bcab531..2b5aa4b 100644
+index f1274ba..d4f9c42 100644
 --- a/integration-cli/docker_cli_push_test.go
 +++ b/integration-cli/docker_cli_push_test.go
 @@ -9,7 +9,7 @@ import (
@@ -47,10 +47,10 @@ index bcab531..2b5aa4b 100644
  
  // pulling an image from the central registry should work
 diff --git a/integration-cli/utils.go b/integration-cli/utils.go
-index f67ee78..77c5720 100644
+index 85e6f1c..b9b5e0e 100644
 --- a/integration-cli/utils.go
 +++ b/integration-cli/utils.go
-@@ -15,7 +15,7 @@ import (
+@@ -17,7 +17,7 @@ import (
  	"syscall"
  	"time"
  
@@ -60,16 +60,17 @@ index f67ee78..77c5720 100644
  
  func getExitCode(err error) (int, error) {
 diff --git a/integration/api_test.go b/integration/api_test.go
-index ab2c307..a520355 100644
+index e978c31..840855b 100644
 --- a/integration/api_test.go
 +++ b/integration/api_test.go
-@@ -14,11 +14,11 @@ import (
+@@ -14,12 +14,12 @@ import (
  	"testing"
  	"time"
  
 +	"archive/tar"
  	"github.com/docker/docker/api"
  	"github.com/docker/docker/api/server"
+ 	"github.com/docker/docker/builder"
  	"github.com/docker/docker/engine"
  	"github.com/docker/docker/runconfig"
 -	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
@@ -77,7 +78,7 @@ index ab2c307..a520355 100644
  
  func TestSaveImageAndThenLoad(t *testing.T) {
 diff --git a/integration/utils_test.go b/integration/utils_test.go
-index 32ca8e0..a283597 100644
+index 2e90e4f..9d0ebc3 100644
 --- a/integration/utils_test.go
 +++ b/integration/utils_test.go
 @@ -14,7 +14,7 @@ import (
@@ -90,7 +91,7 @@ index 32ca8e0..a283597 100644
  	"github.com/docker/docker/builtins"
  	"github.com/docker/docker/daemon"
 diff --git a/pkg/archive/archive.go b/pkg/archive/archive.go
-index 68e5c1d..b54bad3 100644
+index bfa6e18..7a3474a 100644
 --- a/pkg/archive/archive.go
 +++ b/pkg/archive/archive.go
 @@ -16,7 +16,7 @@ import (
@@ -116,36 +117,36 @@ index 6cd95d5..dbe8d5e 100644
  
  func TestCmdStreamLargeStderr(t *testing.T) {
 diff --git a/pkg/archive/archive_unix.go b/pkg/archive/archive_unix.go
-index c0e8aee..dd1b767 100644
+index cbce65e..88652e5 100644
 --- a/pkg/archive/archive_unix.go
 +++ b/pkg/archive/archive_unix.go
-@@ -6,7 +6,7 @@ import (
- 	"errors"
+@@ -7,7 +7,7 @@ import (
+ 	"os"
  	"syscall"
  
 -	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 +	"archive/tar"
  )
  
- func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+ // canonicalTarNameForPath returns platform-specific filepath
 diff --git a/pkg/archive/archive_windows.go b/pkg/archive/archive_windows.go
-index 3cc2493..6312df3 100644
+index 6caef3b..6c92c7d 100644
 --- a/pkg/archive/archive_windows.go
 +++ b/pkg/archive/archive_windows.go
-@@ -3,7 +3,7 @@
- package archive
+@@ -7,7 +7,7 @@ import (
+ 	"os"
+ 	"strings"
  
- import (
 -	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 +	"archive/tar"
  )
  
- func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+ // canonicalTarNameForPath returns platform-specific filepath
 diff --git a/pkg/archive/changes.go b/pkg/archive/changes.go
-index 85217f6..bc67e90 100644
+index c3cb4eb..1d6194b 100644
 --- a/pkg/archive/changes.go
 +++ b/pkg/archive/changes.go
-@@ -10,7 +10,7 @@ import (
+@@ -11,7 +11,7 @@ import (
  	"syscall"
  	"time"
  
@@ -155,7 +156,7 @@ index 85217f6..bc67e90 100644
  	log "github.com/Sirupsen/logrus"
  	"github.com/docker/docker/pkg/pools"
 diff --git a/pkg/archive/diff.go b/pkg/archive/diff.go
-index ca28207..1e9b968 100644
+index b5eb63f..87e3ec4 100644
 --- a/pkg/archive/diff.go
 +++ b/pkg/archive/diff.go
 @@ -9,7 +9,7 @@ import (

--- a/debian/repack/prune/vendor
+++ b/debian/repack/prune/vendor
@@ -1,1 +1,2 @@
 ./vendor
+./Godeps/_workspace

--- a/debian/rules
+++ b/debian/rules
@@ -1,33 +1,24 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
-# Tell dh-golang where this package lives upstream
-export DH_GOPKG := github.com/docker/docker
-# Tell dh-golang that we DO need subpackages
-export DH_GOLANG_INSTALL_ALL := 1
-
+DOCKER_GOPKG = github.com/docker/docker
 LIBCONTAINER_GOPKG = github.com/docker/libcontainer
 LIBTRUST_GOPKG = github.com/docker/libtrust
+DISTRIBUTION_GOPKG = github.com/docker/distribution
 
 # temporary build path (see http://golang.org/doc/code.html#GOPATH)
-export GOPATH := $(CURDIR)/obj-$(DEB_BUILD_GNU_TYPE)
+export GOPATH = $(CURDIR)/.gopath
+GOPATH_PACKAGED = /usr/share/gocode
 
 # a few helpful variables for deduplication
-INITDIR = /usr/lib/docker.io
-INITPATH = ${INITDIR}/dockerinit
+DOCKER_BINPATH = /usr/bin/docker
 DOCKER_VERSION = $(shell cat VERSION)
 
-export DOCKER_GITCOMMIT := $(shell ./debian/helpers/gitcommit.sh $(DOCKER_VERSION))
-export DOCKER_INITPATH := ${INITPATH}
-
-
-# see https://github.com/docker/docker/blob/v1.5.0/project/PACKAGERS.md#build-dependencies
-# and https://github.com/docker/docker/blob/v1.5.0/project/PACKAGERS.md#docker_buildtags
-BTRFS_VERSION = $(shell dpkg-query -f '$${Version}' -W btrfs-tools)
-OLD_BTRFS_BUILDTAG = $(shell dpkg --compare-versions $(BTRFS_VERSION) '>=' '3.16.1~' || echo btrfs_noversion)
+export DOCKER_GITCOMMIT = $(shell ./debian/helpers/gitcommit.sh $(DOCKER_VERSION))
+export DOCKER_INITPATH = /usr/lib/docker.io/dockerinit
 
 # AppArmor can be optionally used in Debian and is there by default in Ubuntu, so we need support for it compiled into our binary
-export DOCKER_BUILDTAGS := apparmor $(OLD_BTRFS_BUILDTAG)
+export DOCKER_BUILDTAGS = apparmor
 
 
 APPARMOR_RECOMMENDS = $(shell dpkg-vendor --is Ubuntu && echo apparmor)
@@ -39,50 +30,56 @@ override_dh_gencontrol:
 override_dh_auto_build:
 	@bash -c '{ [ "$$DOCKER_GITCOMMIT" ]; } || { echo; echo "error: missing DOCKER_GITCOMMIT - see debian/upstream-version-gitcommits"; echo; exit 2; } >&2'
 	
-	@# this is especially for easier build-testing of nightlies
-	@[ -d libcontainer ] || { [ -d vendor/src/$(LIBCONTAINER_GOPKG) ] && ln -sf vendor/src/$(LIBCONTAINER_GOPKG) libcontainer; }
-	@[ -d libtrust ] || { [ -d vendor/src/$(LIBTRUST_GOPKG) ] && ln -sf vendor/src/$(LIBTRUST_GOPKG) libtrust; }
+	# make sure we have our multitarball deps (from tarballs or from vendor/ in nightlies)
+	[ -d libcontainer ] || { [ -d vendor/src/$(LIBCONTAINER_GOPKG) ] && ln -sf vendor/src/$(LIBCONTAINER_GOPKG) libcontainer; }
+	[ -d libtrust ] || { [ -d vendor/src/$(LIBTRUST_GOPKG) ] && ln -sf vendor/src/$(LIBTRUST_GOPKG) libtrust; }
+	[ -d distribution ] || { [ -d vendor/src/$(DISTRIBUTION_GOPKG) ] && ln -sf vendor/src/$(DISTRIBUTION_GOPKG) distribution; }
 	
-	@# we need to make sure our multitarball deps are in our GOPATH
-	@mkdir -p "$$GOPATH/src/$(dir $(LIBCONTAINER_GOPKG))" "$$GOPATH/src/$(dir $(LIBTRUST_GOPKG))"
-	ln -sf "$$(readlink -f libcontainer)" "$(GOPATH)/src/$(dir $(LIBCONTAINER_GOPKG))"
-	ln -sf "$$(readlink -f libtrust)" "$(GOPATH)/src/$(dir $(LIBTRUST_GOPKG))"
+	# we need to make sure all deps are in our GOPATH
+	mkdir -p "$(GOPATH)"
+	mkdir -p \
+		"$$GOPATH/src/$(dir $(DOCKER_GOPKG))" \
+		"$$GOPATH/src/$(dir $(LIBCONTAINER_GOPKG))" \
+		"$$GOPATH/src/$(dir $(LIBTRUST_GOPKG))" \
+		"$$GOPATH/src/$(dir $(DISTRIBUTION_GOPKG))"
+	ln -sfT "$$(readlink -f .)" "$$GOPATH/src/$(DOCKER_GOPKG)"
+	ln -sfT "$$(readlink -f libcontainer)" "$$GOPATH/src/$(LIBCONTAINER_GOPKG)"
+	ln -sfT "$$(readlink -f libtrust)" "$$GOPATH/src/$(LIBTRUST_GOPKG)"
+	ln -sfT "$$(readlink -f distribution)" "$$GOPATH/src/$(DISTRIBUTION_GOPKG)"
 	
+	# build "docker" and "dockerinit"
+	GOPATH="$$GOPATH:$(GOPATH_PACKAGED)" \
 	./hack/make.sh dynbinary
 	
 	# compile man pages
-	./docs/man/md2man-all.sh
+	./docs/man/md2man-all.sh -q
 
 
 override_dh_auto_install:
-	dh_auto_install
-	
 	# install docker binary
-	mkdir -p debian/docker.io/usr/bin
-	mv bundles/${DOCKER_VERSION}/dynbinary/docker-${DOCKER_VERSION} debian/docker.io/usr/bin/docker
+	mkdir -p debian/docker.io/$(dir $(DOCKER_BINPATH))
+	cp -aT bundles/$(DOCKER_VERSION)/dynbinary/docker-$(DOCKER_VERSION) debian/docker.io/$(DOCKER_BINPATH)
 	
 	# install dockerinit binary
-	mkdir -p debian/docker.io/${INITDIR}
-	mv bundles/${DOCKER_VERSION}/dynbinary/dockerinit-${DOCKER_VERSION} debian/docker.io/${INITPATH}
+	mkdir -p debian/docker.io/$(dir $(DOCKER_INITPATH))
+	cp -aT bundles/$(DOCKER_VERSION)/dynbinary/dockerinit-$(DOCKER_VERSION) debian/docker.io/$(DOCKER_INITPATH)
 	
 	# Most of the source of docker does not make a library,
 	#   so only ship the reusable parts (and in a separate package).
-	mkdir -p debian/golang-docker-dev/usr/share/gocode/src/${DH_GOPKG}
-	mv -v \
-		debian/tmp/usr/share/gocode/src/${DH_GOPKG}/pkg \
-		debian/golang-docker-dev/usr/share/gocode/src/${DH_GOPKG}/
-	mkdir -p debian/golang-docker-dev/usr/share/gocode/src/$(dir $(LIBCONTAINER_GOPKG))
-	@# this is especially for easier build-testing of nightlies
-	@[ -d debian/tmp/usr/share/gocode/src/${DH_GOPKG}/libcontainer ] || { [ -d debian/tmp/usr/share/gocode/src/${DH_GOPKG}/vendor/src/$(LIBCONTAINER_GOPKG) ] && mv debian/tmp/usr/share/gocode/src/${DH_GOPKG}/vendor/src/$(LIBCONTAINER_GOPKG) debian/tmp/usr/share/gocode/src/${DH_GOPKG}/libcontainer; }
-	mv -v \
-		debian/tmp/usr/share/gocode/src/${DH_GOPKG}/libcontainer \
-		debian/golang-docker-dev/usr/share/gocode/src/$(dir $(LIBCONTAINER_GOPKG))
-	rm -rf debian/tmp/usr/share/gocode
+	@set -ex; \
+		for package in \
+			$(DOCKER_GOPKG)/autogen/dockerversion \
+			$(DOCKER_GOPKG)/pkg \
+			$(LIBCONTAINER_GOPKG) \
+		; do \
+			mkdir -p "debian/golang-docker-dev/$(GOPATH_PACKAGED)/src/$$package"; \
+			cp -aT "$$(readlink -f "$$GOPATH/src/$$package")" "debian/golang-docker-dev/$(GOPATH_PACKAGED)/src/$$package"; \
+		done
 
 
-# the SHA1 of dockerinit is important: don't strip it
-# also, Go has lots of problems with stripping, so just don't
 override_dh_strip:
+	# the SHA1 of dockerinit is important: don't strip it
+	# also, Go has lots of problems with stripping, so just don't
 
 
 override_dh_auto_test:
@@ -91,18 +88,6 @@ override_dh_auto_test:
 override_dh_installinit:
 	dh_installinit --name=docker
 
-override_dh_systemd_enable:
-	dh_systemd_enable -pdocker.io --no-enable docker.service
-	dh_systemd_enable -pdocker.io docker.socket
-
-override_dh_systemd_start:
-	dh_systemd_start -pdocker.io --no-start docker.service
-	dh_systemd_start -pdocker.io docker.socket
-
-
-override_dh_installchangelogs:
-	dh_installchangelogs CHANGELOG.md
-
 
 override_dh_installudev:
 	# use priority z80 to match the upstream priority of 80
@@ -110,10 +95,16 @@ override_dh_installudev:
 
 
 override_dh_auto_clean:
+	dh_auto_clean
+	
+	# GOPATH is created by us
+	rm -rf "$(GOPATH)"
+	
+	# autogen is created by hack/make.sh
 	# bundles is created by hack/make.sh
 	# docs/man/man*/ is created by docs/man/md2man-all.sh
-	rm -rf bundles docs/man/man*/
+	rm -rf autogen bundles docs/man/man*/
 
 
 %:
-	dh $@ --buildsystem=golang --with=golang,systemd,bash-completion
+	dh $@ --with=systemd,bash-completion


### PR DESCRIPTION
@paultag can you give me a sanity check on my `debian/rules` changes here?

I was looking over our `debian/rules` file and realized we really don't actually use `dh-golang`, and do some really funky dancing just to work around the way _it_ works, where the version without it (included here) is more straightforward.  This sounds a little crazy, which is why I'm looking for a sanity check. :innocent:
