### PR TITLE
Add a preinst script to fail if aufs is in use

### DIFF
--- a/debian/NEWS
+++ b/debian/NEWS
@@ -1,0 +1,36 @@
+docker.io (20.10.2-0ubuntu2) UNRELEASED; urgency=medium
+
+  As of version 20.10.2-0ubuntu2, upgrading the docker.io package will fail if
+  any containers are still using AUFS. It will be necessary to take some
+  measures to move existing containers away from aufs and delete the directory
+  /var/lib/docker/aufs before upgrading can succeed. See the previous NEWS
+  entry for instructions on moving away from AUFS.
+
+ -- William 'jawn-smith' Wilson <william.wilson@canonical.com>  Wed, 24 Feb 2021 16:06:03 -0600
+
+docker.io (1.8.3~ds1-3) unstable; urgency=medium
+
+  As of src:linux 4.0+ (specifically, >= 3.18-1~exp1), AUFS support is no longer
+  included in official Debian-compiled kernels.  What this means to Docker users
+  is that if your existing images are stored within the "AUFS" graph driver that
+  once you update your kernel, your images (and containers) will become
+  inaccessible (due to the kernel not having the necessary aufs modules to mount
+  them).  To recover from this, there are a couple options (detailed below).
+
+  1. Use the included nuke script to blow away your existing "/var/lib/docker"
+     contents and start fresh with Linux 4.0+:
+
+       service docker stop
+       /usr/share/docker.io/contrib/nuke-graph-directory.sh /var/lib/docker
+       service docker start
+
+  2. Use "docker save" (see "docker help save" for usage) before booting 4.0+ to
+     preserve your images on-disk as tar files, then follow the nuke step from
+     the previous option followed by using "docker load" to re-load your images.
+
+  3. Update to src:linux >= 4.1.1-1~exp1 ("aufs: Apply patches to enable
+     building aufs out-of-tree"), and then compile the aufs modules out-of-tree
+     (a package for doing this module compilation automatically doesn't yet
+     exist at the time of this writing, but might in the future).
+
+ -- Tianon Gravi <tianon@debian.org>  Tue, 01 Dec 2015 01:02:44 -0800

--- a/debian/NEWS
+++ b/debian/NEWS
@@ -6,6 +6,11 @@ docker.io (20.10.2-0ubuntu2) UNRELEASED; urgency=medium
   /var/lib/docker/aufs before upgrading can succeed. See the previous NEWS
   entry for instructions on moving away from AUFS.
 
+  Note: Option 3 from the previous NEWS entry is no longer going to be a valid
+        option moving forward. Users will have to either migrate their
+        containers to a supported storage driver or maintain their own kernel
+        builds with AUFS support.
+
  -- William 'jawn-smith' Wilson <william.wilson@canonical.com>  Wed, 24 Feb 2021 16:06:03 -0600
 
 docker.io (1.8.3~ds1-3) unstable; urgency=medium

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+docker.io (20.10.2-0ubuntu2) UNRELEASED; urgency=medium
+
+  * Add a preinst check for aufs storage-driver to fail the upgrade.
+    (LP: #1907713)
+
+ -- William 'jawn-smith' Wilson <william.wilson@canonical.com>  Wed, 24 Feb 2021 10:37:59 -0600
+
 docker.io (20.10.2-0ubuntu1) hirsute; urgency=medium
 
   * New upstream release.

--- a/debian/docker.io.preinst
+++ b/debian/docker.io.preinst
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+if [ -e "/var/lib/docker/aufs" ]; then
+	echo "The aufs storage-driver is no longer supported."
+	echo "Please ensure that none of your containers are"
+	echo "using the aufs storage driver, remove the directory"
+	echo "/var/lib/docker/aufs and try again."
+	exit 1
+fi


### PR DESCRIPTION
The aufs storage driver is deprecated. If any containers are using aufs, we should block the upgrade of the docker package so that the users can make the necessary changes to get off of aufs.

The existence of /var/lib/docker/aufs is the best indicator for whether any containers may be using aufs. This is how docker's backend code checks the valid storage drivers, and avoids any complications of having multiple docker daemons running simultaneously.