### PR TITLE
[Focal] Fix service restart on upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+docker.io (20.10.2-0ubuntu1~20.04.2) focal; urgency=medium
+
+  * d/rules: pass --no-restart-after-upgrade to dh_installsystemd.
+    The --no-start flag we pass to dh_installsystemd in d/rules is supposed
+    to also disable --restart-after-upgrade, however, this feature was buggy
+    before the now fixed debhelper 13. Due to that we need to manually add
+    --no-restart-after-upgrade.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Mon, 29 Mar 2021 16:10:09 -0300
+
 docker.io (20.10.2-0ubuntu1~20.04.1) focal; urgency=medium
 
   * Backport version 20.10.2-0ubuntu1 from Hirsute (LP: #1919322).

--- a/debian/rules
+++ b/debian/rules
@@ -111,7 +111,7 @@ override_dh_installinit:
 	dh_installinit --name=docker --no-start
 
 override_dh_installsystemd:
-	dh_installsystemd --name=docker --no-start
+	dh_installsystemd --name=docker --no-start --no-restart-after-upgrade
 
 override_dh_installudev:
 	# use priority z80 to match the upstream priority of 80


### PR DESCRIPTION
During upgrades users can select whether they want to restart the service or not. We are relying on a debhelper feature which is buggy in Focal, to fix it we need to pass `--no-restart-after-upgrade` to `dh_installsystemd` manually. Without this addition if the user selects to not restart the service (also the default) it will be restarted anyway and all the containers running will go away.