### PR TITLE
Improve the library package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+docker.io (20.10.7-0ubuntu2) UNRELEASED; urgency=medium
+
+  * Ship libnetwork into the golang-github-docker-docker-dev package.
+    - d/golang-github-docker-docker-dev.install: add libnetwork directories.
+    - d/control: add runtime dependency on golang-github-ishidawataru-sctp-dev
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Fri, 28 May 2021 10:55:12 -0300
+
 docker.io (20.10.7-0ubuntu1) impish; urgency=medium
 
   * New upstream release.

--- a/debian/control
+++ b/debian/control
@@ -82,7 +82,9 @@ Description: Docker container engine - Vim highlighting syntax files
 
 Package: golang-github-docker-docker-dev
 Architecture: all
-Depends: golang-github-docker-docker-credential-helpers-dev, ${misc:Depends}
+Depends: golang-github-ishidawataru-sctp-dev,
+         golang-github-docker-docker-credential-helpers-dev,
+         ${misc:Depends}
 Replaces: golang-docker-dev (<< 1.8.2~ds1-1~)
 Breaks: golang-docker-dev (<< 1.8.2~ds1-1~)
 Provides: golang-docker-dev

--- a/debian/control
+++ b/debian/control
@@ -84,6 +84,7 @@ Package: golang-github-docker-docker-dev
 Architecture: all
 Depends: golang-github-ishidawataru-sctp-dev,
          golang-github-docker-docker-credential-helpers-dev,
+         golang-github-seccomp-libseccomp-golang-dev,
          ${misc:Depends}
 Replaces: golang-docker-dev (<< 1.8.2~ds1-1~)
 Breaks: golang-docker-dev (<< 1.8.2~ds1-1~)

--- a/debian/golang-github-docker-docker-dev.install
+++ b/debian/golang-github-docker-docker-dev.install
@@ -13,3 +13,11 @@ engine/rootless usr/share/gocode/src/github.com/docker/docker/
 engine/vendor usr/share/gocode/src/github.com/docker/docker/
 cli/cli usr/share/gocode/src/github.com/docker/cli/
 cli/opts usr/share/gocode/src/github.com/docker/cli/
+libnetwork/datastore usr/share/gocode/src/github.com/docker/libnetwork/
+libnetwork/discoverapi usr/share/gocode/src/github.com/docker/libnetwork/
+libnetwork/ipamutils usr/share/gocode/src/github.com/docker/libnetwork/
+libnetwork/ns usr/share/gocode/src/github.com/docker/libnetwork/
+libnetwork/options usr/share/gocode/src/github.com/docker/libnetwork/
+libnetwork/resolvconf usr/share/gocode/src/github.com/docker/libnetwork/
+libnetwork/testutils usr/share/gocode/src/github.com/docker/libnetwork/
+libnetwork/types usr/share/gocode/src/github.com/docker/libnetwork/


### PR DESCRIPTION
I am working on `nomad` to try to sync it from Debian but it FTBFS in Impish. The main reason is because our docker library package does not provide the `libnetwork` component in the searchable path, it is inside the vendor directory and it is not found during the build.

With the proposed changes I can fix this part of the build failure, however, I am not sure if this is totally right because I added a new runtime dependency on `golang-github-ishidawataru-sctp-dev` which is already available in the vendor directory. Is this the right approach to fix this issue?

Moreover, after fixing the problem above with the proposed changes `nomad` still FTBFS in Impish because it requires the `distribution` component which if I recall we removed in the move to version `20.10`:

```
src/github.com/hashicorp/nomad/drivers/docker/utils.go:15:2: cannot find package "github.com/docker/distribution/reference" in any of:
	/<<PKGBUILDDIR>>/_build/src/github.com/hashicorp/nomad/vendor/github.com/docker/distribution/reference (vendor tree)
	/usr/lib/go-1.16/src/github.com/docker/distribution/reference (from $GOROOT)
	/<<PKGBUILDDIR>>/_build/src/github.com/docker/distribution/reference (from $GOPATH)
```

Should we add back this `distribution` component to support the case above? Only the function `ParseNormalizedNamed` from this component is used by `nomad` but I did not investigate how to patch this out.