### PR TITLE
Impish import new version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,14 @@ docker.io (20.10.7-0ubuntu1) UNRELEASED; urgency=medium
   * New upstream release.
     - Among new features and bug fixes, the CVE-2021-21284 and CVE-2021-21285
       were addressed.
+  * d/watch: adjust regex to correctly match the tarball files.
+  * d/rules: make some improvements.
+    - Adjust regex in the build-manpages target due to some upstream changes.
+    - Separately install the systemd service and socket.
+    - Tell dh_installsystemd to not stop the service during the upgrade.
+      The previous implementation worked fine until debhelper compat 10 where
+      dh_systemd_start was still a thing. In compat 11, it was deprecated
+      which means that piece of code was not called.
 
  -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 03 Aug 2021 15:58:42 -0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+docker.io (20.10.7-0ubuntu1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+    - Among new features and bug fixes, the CVE-2021-21284 and CVE-2021-21285
+      were addressed.
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 03 Aug 2021 15:58:42 -0300
+
 docker.io (20.10.2-0ubuntu2) hirsute; urgency=medium
 
   [ William 'jawn-smith' Wilson ]

--- a/debian/rules
+++ b/debian/rules
@@ -82,7 +82,7 @@ _build-manpages:
 	cd '$(OUR_GOPATH)/src/github.com/docker/cli' \
 		&& export PATH='$(OUR_GOPATH)/bin':"$$PATH" \
 		&& sed 's!/tmp/gen-manpages!$(CURDIR)/debian/tmp/gen-manpages!g' scripts/docs/generate-man.sh \
-		&& sed 's!/go/bin/md2man!$(OUR_GOPATH)/bin/md2man!g' scripts/docs/generate-man.sh \
+		&& sed 's!/go/bin/go-md2man!$(OUR_GOPATH)/bin/go-md2man!g' scripts/docs/generate-man.sh \
 			| bash
 
 _build-engine:

--- a/debian/rules
+++ b/debian/rules
@@ -111,7 +111,8 @@ override_dh_installinit:
 	dh_installinit --name=docker --no-start
 
 override_dh_installsystemd:
-	dh_installsystemd --name=docker --no-start
+	dh_installsystemd --name=docker --no-start -pdocker.io docker.service
+	dh_installsystemd --name=docker --no-start -pdocker.io docker.socket
 
 override_dh_installudev:
 	# use priority z80 to match the upstream priority of 80

--- a/debian/rules
+++ b/debian/rules
@@ -111,8 +111,13 @@ override_dh_installinit:
 	dh_installinit --name=docker --no-start
 
 override_dh_installsystemd:
-	dh_installsystemd --name=docker --no-start -pdocker.io docker.service
-	dh_installsystemd --name=docker --no-start -pdocker.io docker.socket
+	# We take care of determining whether the docker.io service should be
+	# restarted during upgrades or not ourselves, based on the debconf
+	# choice made by the user during installation.  For this reason, we
+	# invoke dh_installsystemd with "--no-stop-on-upgrade" in order
+	# to avoid indiscriminately stopping the service during upgrades.
+	dh_installsystemd --name=docker --no-start -pdocker.io --no-stop-on-upgrade docker.service
+	dh_installsystemd --name=docker --no-start -pdocker.io --no-stop-on-upgrade docker.socket
 
 override_dh_installudev:
 	# use priority z80 to match the upstream priority of 80
@@ -127,14 +132,6 @@ override_dh_shlibdeps:
 
 override_dh_auto_clean:
 	@# stop debhelper from doing "make clean"
-
-override_dh_systemd_start:
-	# We take care of determining whether the docker.io service should be
-	# restarted during upgrades or not ourselves, based on the debconf
-	# choice made by the user during installation.  For this reason, we
-	# invoke dh_systemd_start with "-r" in order to avoid indiscriminately
-	# stopping the service during upgrades.
-	dh_systemd_start --package=docker.io -r
 
 %:
 	dh $@ --with=bash-completion

--- a/debian/watch
+++ b/debian/watch
@@ -8,13 +8,13 @@ component=engine,\
 dversionmangle=s/[+~](debian|dfsg|ds|deb)\d*$//,\
 uversionmangle=s/(\d)[_\.\-\+]?((RC|rc|pre|dev|beta|alpha)\d*)$/$1~$2/,\
 filenamemangle=s/.+\/v(\d\S*)\.tar\.gz/docker.io_$1.orig-engine.tar.gz/ \
-  https://github.com/moby/moby/tags .*/archive/v(\d\S*).tar.gz
+  https://github.com/moby/moby/tags .*/archive/.*v(\d\S*).tar.gz
 
 opts=\
 component=cli,\
 uversionmangle=s/(\d)[_\.\-\+]?((RC|rc|pre|dev|beta|alpha)\d*)$/$1~$2/,\
 filenamemangle=s/.+\/v(\d\S*)\.tar\.gz/docker.io_$1.orig-cli.tar.gz/ \
-  https://github.com/docker/cli/tags .*/archive/v(\d\S*).tar.gz
+  https://github.com/docker/cli/tags .*/archive/.*v(\d\S*).tar.gz
 
 opts=\
 component=libnetwork,\


### PR DESCRIPTION
Import version `20.10.7`. I found a bug not caught when I bumped the debhelper compat level to 11, so I took advantage to also fix that.

Here is a PPA with the proposed package:

https://launchpad.net/~lucaskanashiro/+archive/ubuntu/container-stack

And `autopkgtest` is still happy:

```
autopkgtest [17:55:47]: @@@@@@@@@@@@@@@@@@@@ summary
basic-smoke          PASS
docker-in-lxd        PASS
```