### PR TITLE
Upgrade and restart docker-in-lxd container

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+docker.io (20.10.7-0ubuntu3) impish; urgency=medium
+
+  * d/t/docker-in-lxd:
+    Perform a full upgrade and restart of the container before attempting
+    to install docker.io. (LP: #1942276)
+
+ -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Wed, 01 Sep 2021 18:58:31 -0400
+
 docker.io (20.10.7-0ubuntu2) impish; urgency=medium
 
   * Ship libnetwork into the golang-github-docker-docker-dev package.

--- a/debian/tests/docker-in-lxd
+++ b/debian/tests/docker-in-lxd
@@ -156,7 +156,15 @@ then
     done
 fi
 
+# Perform a full upgrade and restart the container before attempting
+# to install docker.io.  See
+# https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1942276 for
+# more details.
 lxc exec docker -- apt-get update
+lxc exec docker --env DEBIAN_FRONTEND=noninteractive -- apt-get full-upgrade -y
+lxc restart docker
+sleep 5
+
 lxc exec docker --env DEBIAN_FRONTEND=noninteractive -- apt-get install docker.io -y
 
 # Now basically run the simplest possible test inside the container.


### PR DESCRIPTION
This PR fixes the bug reported here:

https://bugs.launchpad.net/ubuntu/+source/docker.io/+bug/1942276

Note that there are actually two things going on.

The first one is the glibc problem described in the bug, which is real
and affects other packages, not only docker.io.  This problem is being
actively investigated as we speak.

The second problem, which is much smaller but was actually what
allowed us to bump into the glibc issue, is the fact that the LXD
container being used to test things in the `docker-in-lxd` test is not
upgraded before the tests happen.  I believe it is a good practice to
always make sure that we're testing stuff using an up-to-date
container here, especially when we're dealing with `-proposed`
repositories inside it.

The patch is simple and I've verified that the test is now passing
here, even when testing with the problematic glibc (that's because
we're now always restarting the container after the upgrade, which
works around the glibc bug).