### PR TITLE
Improve docker-in-lxd dep8 test

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+docker.io (20.10.7-0ubuntu5) UNRELEASED; urgency=medium
+
+  * d/t/docker-in-lxd:
+    Improve dep8 test.  Make it run a more complex test against an
+    ubuntu:devel docker container, especially because glibc updates might
+    break docker.io.  Improve test reliability when running autopkgtest
+    locally.
+
+ -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Thu, 16 Sep 2021 16:47:25 -0400
+
 docker.io (20.10.7-0ubuntu4) impish; urgency=medium
 
   * d/p/seccomp-add-support-for-clone3-syscall-in-default-policy.patch: Fix

--- a/debian/tests/docker-in-lxd
+++ b/debian/tests/docker-in-lxd
@@ -45,6 +45,17 @@ lxd_extension() {
   lxc info | grep -q "^\- ${1}$"
 }
 
+# Copy the local apt package archive over to the lxd container.
+# This function assumes that the container is named "docker".
+copy_local_apt_files() {
+  for local_source in $(apt-get indextargets | grep-dctrl -F URI -e '^file:///' -sURI); do
+    local_source=${local_source#file://}
+    local_dir=$(dirname "${local_source}")
+    lxc exec docker -- mkdir -p "${local_dir}"
+    tar -cC "${local_dir}" . | lxc exec docker -- tar -xC "${local_dir}"
+  done
+}
+
 time lxd waitready --timeout 600
 
 # Attempt to auto-configure ipv4, but only when really running under
@@ -105,12 +116,7 @@ lxc exec docker -- rm -rf /etc/apt
 lxc exec docker -- mkdir /etc/apt
 tar -cC /etc/apt . | lxc exec docker -- tar -xC /etc/apt
 
-for local_source in $(apt-get indextargets | grep-dctrl -F URI -e '^file:///' -sURI); do
-    local_source=${local_source#file://}
-    local_dir=$(dirname ${local_source})
-    lxc exec docker -- mkdir -p ${local_dir}
-    tar -cC ${local_dir} . | lxc exec docker -- tar -xC ${local_dir}
-done
+copy_local_apt_files
 
 if [ -n "${http_proxy:-}" ]; then
     lxc exec docker -- mkdir -p /etc/systemd/system/docker.service.d
@@ -165,22 +171,49 @@ lxc exec docker --env DEBIAN_FRONTEND=noninteractive -- apt-get full-upgrade -y
 lxc restart docker
 sleep 5
 
+# We call this again here because if the local apt repository lived
+# under /tmp, it won't be available anymore after a container restart.
+copy_local_apt_files
+lxc exec docker -- apt-get update
+
 lxc exec docker --env DEBIAN_FRONTEND=noninteractive -- apt-get install docker.io -y
 
 # Now basically run the simplest possible test inside the container.
 
 case ${arch} in
-    amd64)
-        image=hello-world;;
-    armhf|i386|s390x)
-        image=${arch}/hello-world;;
+    amd64|i386|s390x)
+        image_hello_world=${arch}/hello-world
+        image_ubuntu="${arch}/ubuntu:devel";;
+    armhf)
+        image_hello_world=arm32v7/hello-world
+        image_ubuntu=arm32v7/ubuntu:devel;;
     ppc64el)
-        image=ppc64le/hello-world;;
+        image_hello_world=ppc64le/hello-world
+        image_ubuntu=ppc64le/ubuntu:devel;;
     arm64)
-        image=aarch64/hello-world;;
+        image_hello_world=arm64v8/hello-world
+        image_ubuntu=arm64v8/ubuntu:devel;;
     *)
         echo "unknown arch: ${arch}"
         exit 2;;
 esac
 
-lxc exec docker -- docker run ${image}
+lxc exec docker -- docker run "${image_hello_world}"
+
+ubuntu_devel_suite=$(lxc exec docker -- docker run --rm "${image_ubuntu}" \
+                         /bin/bash -c 'source /etc/lsb-release && echo "$DISTRIB_CODENAME"')
+
+# We also need to run some commands inside an ubuntu:devel container,
+# to make sure that docker.io can work correctly with the latest
+# glibc.
+#
+# It's also important to make sure the docker container is using the
+# same apt configuration from the lxd container, which itself is the
+# same apt configuration from the host.
+#
+# We just want to perform this test when the docker.io package is
+# being tested against the development release of Ubuntu.
+if [ "${ubuntu_devel_suite}" = "${suite}" ]; then
+  lxc exec docker -- docker run -v /etc/apt:/etc/apt "${image_ubuntu}" \
+      /bin/bash -c 'apt-get update; apt-get full-upgrade -y && apt-get install -y hello'
+fi


### PR DESCRIPTION
This PR aims to improve the existing `docker-in-lxd` dep8 test.  The
idea behind it is to run a more useful test after setting everything
up inside the lxd container, especially after (for the second time in
a row) we've a glibc upgrade on Ubuntu break docker.io unnoticed.

Although I could have implemented an extensive test framework here
(testing multiple lxd containers, each one running a supported Ubuntu
version, for example), I decided to start "simple" and just extend the
existing test that runs inside a container whose distribution is the
same as the one being tested by the autopkgtest.

During the two breakages we had (one during the Hirsute cycle, and now
during the Impish cycle), running an `apt-get update && apt-get
upgrade && apt-get install some-package` would fail, so that's the
test that I chose to execute in this case.

Last, but not least, this PR also fixes a latent bug that happened
when you ran autopkgtest locally.  Before this fix, the docker.io
package that was installed inside the lxd container always came from
the official archive.  When you're running the test locally though,
you (almost always) want to install the docker.io package that you've
just built.  This is now supported.

There's a PPA with the proposed change here:

https://launchpad.net/~sergiodj/+archive/ubuntu/docker-autopkgtest-fix/+packages

I ran autopkgtest (using Ubuntu's infra) against it; you can check the
results here:

https://autopkgtest.ubuntu.com/results/autopkgtest-impish-sergiodj-docker-autopkgtest-fix/impish/amd64/d/docker.io/20210916_204108_adb8d@/log.gz