### PR TITLE
d/t/docker-in-lxd: Match "file:/" instead of "file:///" on copy_local_apt_files.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+docker.io (20.10.12-0ubuntu2) jammy; urgency=medium
+
+  * d/t/docker-in-lxd: Match "file:/" instead of "file:///" on
+    copy_local_apt_files.
+    The command "apt-get indextargets" returns a URI field with "file:/"
+    as the prefix.  We've been trying to match "file:///", which is
+    sometimes unsuccessful and leads to errors because the local apt cache
+    is not copied over to the container.  We can use "file:/" instead,
+    which will work on both scenarios.  It's also not a problem to just
+    strip the "file:" prefix, because even paths like "///var/cache" are
+    correctly resolved by the filesystem.
+
+ -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Fri, 14 Jan 2022 14:30:44 -0500
+
 docker.io (20.10.12-0ubuntu1) jammy; urgency=medium
 
   * New upstream release.

--- a/debian/tests/docker-in-lxd
+++ b/debian/tests/docker-in-lxd
@@ -48,8 +48,8 @@ lxd_extension() {
 # Copy the local apt package archive over to the lxd container.
 # This function assumes that the container is named "docker".
 copy_local_apt_files() {
-  for local_source in $(apt-get indextargets | grep-dctrl -F URI -e '^file:///' -sURI); do
-    local_source=${local_source#file://}
+  for local_source in $(apt-get indextargets | grep-dctrl -F URI -e '^file:/' -sURI); do
+    local_source=${local_source#file:}
     local_dir=$(dirname "${local_source}")
     lxc exec docker -- mkdir -p "${local_dir}"
     tar -cC "${local_dir}" . | lxc exec docker -- tar -xC "${local_dir}"


### PR DESCRIPTION
@lucaskanashiro told me that the dep8 tests were failing locally but
working in the Ubuntu infra.  I was able to determine the local
problem (see below), but I'm not entirely sure why the tests don't
fail in the infra.  Maybe the `apt-get indextargets` command behaves
differently there.

The command `apt-get indextargets` returns a URI field with `file:/`
as the prefix.  We've been trying to match `file:///`, which is
sometimes unsuccessful and leads to errors because the local apt cache
is not copied over to the container.  We can use `file:/` instead,
which will work on both scenarios.  It's also not a problem to just
strip the `file:` prefix, because even paths like `///var/cache` are
correctly resolved by the filesystem.