### PR TITLE
Enable riscv64 architecture (LP: #1963920)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+docker.io (20.10.12-0ubuntu4) jammy; urgency=medium
+
+  * Enable riscv64 architecture (LP: #1963920)
+
+ -- Heinrich Schuchardt <heinrich.schuchardt@canonical.com>  Mon, 07 Mar 2022 16:57:50 +0100
+
 docker.io (20.10.12-0ubuntu2) jammy; urgency=medium
 
   * d/t/docker-in-lxd: Match "file:/" instead of "file:///" on

--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Vcs-Browser: https://anonscm.debian.org/cgit/docker/docker.io.git
 XS-Go-Import-Path: github.com/docker/docker
 
 Package: docker.io
-Architecture: amd64 arm64 armhf i386 ppc64el s390x
+Architecture: amd64 arm64 armhf i386 ppc64el riscv64 s390x
 Depends: adduser,
          containerd (>= 1.2.6-0ubuntu1~),
          iptables,


### PR DESCRIPTION
Adding architecture riscv64 for package docker.io. No code changes.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>