### PR TITLE
Fix lxd test lunar

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+docker.io (20.10.21-0ubuntu3) UNRELEASED; urgency=medium
+
+  * d/t/docker-in-lxd: set up lxd container storage using btrfs.
+    Do not use privileged lxd container to run the test.
+    Follow the official Ubuntu documentation:
+    https://ubuntu.com/tutorials/how-to-run-docker-inside-lxd-containers
+
+ -- Lucas Kanashiro <kanashiro@ubuntu.com>  Tue, 28 Feb 2023 09:17:52 -0300
+
 docker.io (20.10.21-0ubuntu2) lunar; urgency=medium
 
   * d/tests: install lxd via snap in docker-in-lxd test.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-docker.io (20.10.21-0ubuntu3) UNRELEASED; urgency=medium
+docker.io (20.10.21-0ubuntu3) lunar; urgency=medium
 
   * d/t/docker-in-lxd: set up lxd container storage using btrfs.
     Do not use privileged lxd container to run the test.

--- a/debian/tests/docker-in-lxd
+++ b/debian/tests/docker-in-lxd
@@ -104,7 +104,12 @@ if [ -n "${noproxy:-}" ]; then
     lxc config set core.proxy_ignore_hosts $noproxy
 fi
 
-lxc launch ubuntu-daily:${suite}/${arch} docker -c security.nesting=true -c security.privileged=true
+# Follow the official tutorial on how to run docker inside lxd containers
+# https://ubuntu.com/tutorials/how-to-run-docker-inside-lxd-containers
+lxc storage create docker-storage btrfs
+lxc storage volume create docker-storage docker-vol
+lxc launch ubuntu-daily:${suite}/${arch} docker -c security.nesting=true -c security.syscalls.intercept.mknod=true -c security.syscalls.intercept.setxattr=true
+lxc storage volume attach docker-storage docker-vol docker /var/lib/docker
 
 defer 'lxc delete --force docker'
 


### PR DESCRIPTION
Instead of running a privileged lxc container, correctly set up the storage to use btrfs (not overlay). With the proposed changes the `docker-in-lxd` DEP-8 test is passing:

```
autopkgtest [09:30:48]: test docker-in-lxd:  - - - - - - - - - - results - - - - - - - - - -
docker-in-lxd        PASS
```