### PR TITLE
Fix dep8 tests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+docker.io (20.10.21-0ubuntu4) UNRELEASED; urgency=medium
+
+  * d/t/docker-in-lxd: Fix dep8 tests to let them copy packages into
+    containers properly by adding the -n flag in the grep-dctrl call
+    (LP: #2012299)
+
+ -- Michal Maloszewski <michal.maloszewski@canonical.com>  Wed, 29 Mar 2023 23:58:52 +0200
+
 docker.io (20.10.21-0ubuntu3) lunar; urgency=medium
 
   * d/t/docker-in-lxd: set up lxd container storage using btrfs.

--- a/debian/tests/docker-in-lxd
+++ b/debian/tests/docker-in-lxd
@@ -51,7 +51,7 @@ lxd_extension() {
 # Copy the local apt package archive over to the lxd container.
 # This function assumes that the container is named "docker".
 copy_local_apt_files() {
-  for local_source in $(apt-get indextargets | grep-dctrl -F URI -e '^file:/' -sURI); do
+  for local_source in $(apt-get indextargets | grep-dctrl -n -F URI -e '^file:/' -sURI); do
     local_source=${local_source#file:}
     local_dir=$(dirname "${local_source}")
     lxc exec docker -- mkdir -p "${local_dir}"


### PR DESCRIPTION
Some lines of code were added to the d/tests/docker-in-lxd to
change the behavior of dep8 tests which incorrectly copied packages
into container.